### PR TITLE
Add markdown code block filtering

### DIFF
--- a/src/commands/deno.ts
+++ b/src/commands/deno.ts
@@ -1,5 +1,5 @@
 import { botCache, cache } from "../../deps.ts";
-import { createCommand } from "../utils/helpers.ts";
+import { createCommand, filterCodeBlock } from "../utils/helpers.ts";
 import { Embed } from "./../utils/Embed.ts";
 import { sleep } from "https://deno.land/x/sleep/mod.ts";
 
@@ -9,7 +9,7 @@ createCommand({
   botChannelPermissions: ["SEND_MESSAGES"],
   arguments: [{ name: "input", type: "...string", required: true }],
   execute: async function (message, args) {
-    const write = Deno.writeTextFile("./execute.ts", `${args.input}`); // here are going to write the archive to the execute.ts
+    const write = Deno.writeTextFile("./execute.ts", `${filterCodeBlock(args.input)}`); // here are going to write the archive to the execute.ts
     write.then(() => console.log("archive edited!"));
 
     const cmd = Deno.run({

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -331,3 +331,19 @@ export async function createEmbedsPagination(
     }
   }
 }
+
+/*
+** Filters out a markdown code block from the input and returns only the code.
+** If a code block isn't found then it will return the input unmodified.
+*/
+export function filterCodeBlock(input: string): string {
+  let trimmed = input.trim();
+
+  if ((trimmed.startsWith("```typescript") || trimmed.startsWith("```javascript")) && trimmed.endsWith("```")) {
+    return trimmed.substring(13, trimmed.length - 3); 
+  } else if (trimmed.startsWith("```") && trimmed.endsWith("```")) {
+    return trimmed.substring(3, trimmed.length - 3);
+  }
+
+  return input;
+}


### PR DESCRIPTION
In Discord you can create code blocks using markdown. On Discord's desktop client this can even include syntax highlight.

It would be nice to be able to wrap the input code in a code block so the rest of the server can see it displayed with syntax highlighting or at the very least a monospaced font.